### PR TITLE
Revert "Match lower case version of todo/fixme"

### DIFF
--- a/grammars/todo.cson
+++ b/grammars/todo.cson
@@ -3,7 +3,7 @@
 'injectionSelector': 'comment, text.plain'
 'patterns': [
   {
-    'match': '(?<!\\w)@?(TODO|todo|FIXME|fixme|CHANGED)\\b'
+    'match': '(?<!\\w)@?(TODO|FIXME|CHANGED)\\b'
     'name': 'storage.type.class.${1:/downcase}'
   }
   {


### PR DESCRIPTION
This reverts commit 5f097c1efe316e7767f292aef53884c2a436e2fa.

Based on discussion in https://github.com/atom/language-todo/issues/4
