### PR TITLE
Add support for "XXX"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TODO support in Atom
 
-Adds syntax highlighting to `TODO`, `FIXME`, and `CHANGED` in comments
+Adds syntax highlighting to `TODO`, `FIXME`, `CHANGED`, and `XXX` in comments
 and text in Atom.
 
 Originally [converted](http://atom.io/docs/latest/converting-a-text-mate-bundle)

--- a/grammars/todo.cson
+++ b/grammars/todo.cson
@@ -3,7 +3,7 @@
 'injectionSelector': 'comment, text.plain'
 'patterns': [
   {
-    'match': '(?<!\\w)@?(TODO|FIXME|CHANGED)\\b'
+    'match': '(?<!\\w)@?(TODO|FIXME|CHANGED|XXX)\\b'
     'name': 'storage.type.class.${1:/downcase}'
   }
   {


### PR DESCRIPTION
Yea? Nay? Vim has it out of the box:

![screen shot 2014-03-18 at 10 05 02 pm](https://f.cloud.github.com/assets/4397642/2455889/436442c6-af0b-11e3-915b-251b9af07804.png)

Personally, I use `XXX` as a semantically shorter-term marker than TODO. :smile: 
