### PR TITLE
clean up radar regex

### DIFF
--- a/grammars/todo.cson
+++ b/grammars/todo.cson
@@ -10,7 +10,7 @@
     'captures':
       '1':
         'name': 'markup.underline.link.radar'
-    'match': '<(ra?dar:/(?:/problem|)/(?:[&0-9]+))>'
+    'match': '<(ra?dar:/(?:/problems?|)/(?:[&0-9]+))>'
     'name': 'storage.type.class.radar'
   }
 ]


### PR DESCRIPTION
rdar://problems/12345678&12345679 is the supported format for multi-radar URLs.
rdar://problem/12345678 is the supported format for single-radar URLs.

This change allows for either.
