### PR TITLE
Add 'text.md' and 'text.markup' to injectionSelector

### DIFF
--- a/grammars/todo.cson
+++ b/grammars/todo.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.todo'
 'name': 'TODO'
-'injectionSelector': 'comment, text.plain, text.md'
+'injectionSelector': 'comment, text.plain, text.md, text.markup'
 'patterns': [
   {
     'match': '(?<!\\w)@?(TODO|FIXME|CHANGED|XXX|IDEA|HACK|NOTE|REVIEW|NB)\\b'

--- a/grammars/todo.cson
+++ b/grammars/todo.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.todo'
 'name': 'TODO'
-'injectionSelector': 'comment, text.plain'
+'injectionSelector': 'comment, text.plain, text.md'
 'patterns': [
   {
     'match': '(?<!\\w)@?(TODO|FIXME|CHANGED|XXX|IDEA|HACK|NOTE|REVIEW|NB)\\b'


### PR DESCRIPTION
Over at [language-markdown](/burodepeper/language-markdown/) we have been discussing (just a little, we know it is silly to argue about it) what our base scope should be, and we decided on `text.md`. We have considered using `text.markup` as it is more semantically correct, but `text.md` seems to more closely follow existing conventions.

Anyway, from our personal experience, we often use Markdown as an ad hoc or more organized todo-list-tool. So we'd like to suggest adding both 'text.md' and 'text.markup' to the injectionSelector of this package for that purpose.