### PR TITLE
Add "TEMP" and "COMBAK" as keywords

### DIFF
--- a/grammars/todo.cson
+++ b/grammars/todo.cson
@@ -3,7 +3,7 @@
 'injectionSelector': 'comment, text.plain'
 'patterns': [
   {
-    'match': '(?<!\\w)@?(TODO|FIXME|CHANGED|XXX|IDEA|HACK|NOTE|REVIEW|NB|BUG|QUESTION)\\b'
+    'match': '(?<!\\w)@?(TODO|FIXME|CHANGED|XXX|IDEA|HACK|NOTE|REVIEW|NB|BUG|QUESTION|COMBAK|TEMP)\\b'
     'name': 'storage.type.class.${1:/downcase}'
   }
   {


### PR DESCRIPTION
`TEMP` is useful for stuff that really is temporary.

`COMBAK` is derived from [Vim's todo highlighting](https://github.com/vim/vim/blob/master/runtime/syntax/vim.vim#L17).