### PR TITLE
Highlight cautionary words

### DIFF
--- a/grammars/todo.cson
+++ b/grammars/todo.cson
@@ -3,7 +3,10 @@
 'injectionSelector': 'comment, text.plain'
 'patterns': [
   {
-    'match': '(?<!\\w)@?(TODO|FIXME|CHANGED|XXX|IDEA|HACK|NOTE|REVIEW|NB|BUG|QUESTION|COMBAK|TEMP)\\b'
+    'match': '''(?x) (?<!\\w) @?
+      (TODO|FIXME|CHANGED|XXX|IDEA|HACK|NOTE|REVIEW|NB|BUG|QUESTION|COMBAK|TEMP
+      |BEWARE|CAUTION|CAVEATS?|DANGER|WARNING)
+      \\b'''
     'name': 'storage.type.class.${1:/downcase}'
   }
   {


### PR DESCRIPTION
I'm worried this might be stretching the focus of this package, but highlighting cautionary words like `WARNING` and `BEWARE` works well in drawing focus to critical segments:

<img src="https://cloud.githubusercontent.com/assets/2346707/20182611/6c54e734-a7b6-11e6-8716-c3b5bc862124.png" width="501" alt="Figure 1" />

<img src="https://cloud.githubusercontent.com/assets/2346707/20182612/6c58462c-a7b6-11e6-9578-38b2618672a7.png" width="450" alt="Figure 2" />

**Full list of additions:**
```
BEWARE
CAUTION
CAVEAT
CAVEATS
DANGER
WARNING
```