### PR TITLE
Hide "TODO" from grammar-selector menu

### DIFF
--- a/.coffeelintignore
+++ b/.coffeelintignore
@@ -1,1 +1,0 @@
-spec/fixtures

--- a/grammars/todo.cson
+++ b/grammars/todo.cson
@@ -1,5 +1,4 @@
 'scopeName': 'text.todo'
-'name': 'TODO'
 'injectionSelector': 'comment, text.plain'
 'patterns': [
   {


### PR DESCRIPTION
### Description of the Change

Follow-up of [`atom/grammar-selector#34`][1], which patched the `grammar-selector` package to hide "internal" or injection-specific grammars from the selection menu. This was recently merged and released in [`grammar-selector@0.49.6`](https://github.com/atom/grammar-selector/tree/v0.49.6). It's now safe to cut redundant `name` fields from grammars which shouldn't be listed alongside "real" languages.

See [`atom/grammar-selector#34`][1] for the original discussion.

/cc @50Wliu

[1]: https://github.com/atom/grammar-selector/pull/34