### PR TITLE
Fix a small issue with text.html.ruby .meta.tag

### DIFF
--- a/snippets/todo.cson
+++ b/snippets/todo.cson
@@ -112,7 +112,7 @@
     'prefix': 'debug'
     'body': '<%# DEBUG: $0 %>'
 
-'.text.html.ruby .meta,tag, .text.erb .meta.tag':
+'.text.html.ruby .meta.tag, .text.erb .meta.tag':
   'todo':
     'prefix': 'todo'
   'fixme':


### PR DESCRIPTION
### Description of the Change

There is a small typo causing a bug with `text.html.ruby` and this PR fixes it