### PR TITLE
Add WARNING keyword to language-todo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Windows Build Status](https://ci.appveyor.com/api/projects/status/gcgb9m7h146lv6qp/branch/master?svg=true)](https://ci.appveyor.com/project/Atom/language-todo/branch/master)
 [![Dependency Status](https://david-dm.org/atom/language-todo.svg)](https://david-dm.org/atom/language-todo)
 
-Adds syntax highlighting to `TODO`, `FIXME`, `CHANGED`, `XXX`, `IDEA`, `HACK`, `NOTE`, `REVIEW`, `NB`, `BUG`, `QUESTION`, `COMBAK`, `TEMP`, `DEBUG` and `OPTIMIZE` in comments
+Adds syntax highlighting to `TODO`, `FIXME`, `CHANGED`, `XXX`, `IDEA`, `HACK`, `NOTE`, `REVIEW`, `NB`, `BUG`, `QUESTION`, `COMBAK`, `TEMP`, `DEBUG`, `OPTIMIZE`, and `WARNING` in comments
 and text in Atom.
 
 Originally [converted](http://flight-manual.atom.io/hacking-atom/sections/converting-from-textmate) from the [TODO TextMate bundle](https://github.com/textmate/todo.tmbundle).

--- a/grammars/todo.cson
+++ b/grammars/todo.cson
@@ -2,7 +2,7 @@
 'injectionSelector': 'comment, text.plain'
 'patterns': [
   {
-    'match': '(?<!\\w)@?(TODO|FIXME|CHANGED|XXX|IDEA|HACK|NOTE|REVIEW|NB|BUG|QUESTION|COMBAK|TEMP|DEBUG|OPTIMIZE)\\b'
+    'match': '(?<!\\w)@?(TODO|FIXME|CHANGED|XXX|IDEA|HACK|NOTE|REVIEW|NB|BUG|QUESTION|COMBAK|TEMP|DEBUG|OPTIMIZE|WARNING)\\b'
     'name': 'storage.type.class.${1:/downcase}'
   }
   {

--- a/snippets/todo.cson
+++ b/snippets/todo.cson
@@ -38,6 +38,9 @@
   'optimize':
     'prefix': 'optimize'
     'body': '# OPTIMIZE: $0'
+  'warning':
+    'prefix': 'warning'
+    'body': '# WARNING: $0'
 
 '.text.haml':
   'todo':
@@ -79,6 +82,9 @@
   'optimize':
     'prefix': 'optimize'
     'body': '-# OPTIMIZE: $0'
+  'warning':
+    'prefix': 'warning'
+    'body': '-# WARNING: $0'
 
 '.text.html.ruby, .text.erb':
   'todo':
@@ -120,6 +126,9 @@
   'optimize':
     'prefix': 'optimize'
     'body': '<%# OPTIMIZE: $0 %>'
+  'warning':
+    'prefix': 'warning'
+    'body': '<%# WARNING: $0 %>'
 
 '.text.html.ruby .meta.tag, .text.erb .meta.tag':
   'todo':
@@ -148,6 +157,8 @@
     'prefix': 'debug'
   'optimize':
     'prefix': 'optimize'
+  'warning':
+    'prefix': 'warning'
 
 '.html.basic':
   'todo':
@@ -189,6 +200,9 @@
   'optimize':
     'prefix': 'optimize'
     'body': '<!-- OPTIMIZE: $0 -->'
+  'warning':
+    'prefix': 'warning'
+    'body': '<!-- WARNING: $0 -->'
 
 '.html.basic .meta.tag':
   'todo':
@@ -217,6 +231,8 @@
     'prefix': 'debug'
   'optimize':
     'prefix': 'optimize'
+  'warning':
+    'prefix': 'warning'
 
 '.source.scss, .source.sass, .source.css.scss, .source.css.sass, .source.css.less, .source.js, .source.go, .source.scala, .source.ts, .source.php':
   'todo':
@@ -258,6 +274,9 @@
   'optimize':
     'prefix': 'optimize'
     'body': '// OPTIMIZE: $0'
+  'warning':
+    'prefix': 'warning'
+    'body': '// WARNING: $0'
 
 '.source.css':
   'todo':
@@ -299,6 +318,9 @@
   'optimize':
     'prefix': 'optimize'
     'body': '/* OPTIMIZE: $0 */'
+  'warning':
+    'prefix': 'warning'
+    'body': '/* WARNING: $0 */'
 
 '.source.css .meta.property-value':
   'todo':
@@ -327,6 +349,8 @@
     'prefix': 'debug'
   'optimize':
     'prefix': 'optimize'
+  'warning':
+    'prefix': 'warning'
 
 '.text.html.php':
   'todo':
@@ -368,3 +392,6 @@
   'optimize':
     'prefix': 'optimize'
     'body': '<?php // OPTIMIZE: $1 ?>$0'
+  'warning':
+    'prefix': 'warning'
+    'body': '<?php // WARNING: $1 ?>$0'


### PR DESCRIPTION
### Requirements
> All new code requires tests to ensure against regressions

^^ How do I run these tests?

### Description of the Change

Add `WARNING` keyword to grammar as another todo keyword. Added to the README and
snippets as well.

### Alternate Designs

I feel like the `WARNING` keyword was something missing from the grammar, a negative callout of sorts with a more long-lived home in a comment that might not be fixed anytime soon.

### Benefits

The `WARNING` keyword is a new negative todo word, and the language highlighting will bring more attention to known issues written in comments/text.

### Possible Drawbacks

Another word in the grammar might be considered bloat. 

Also `WARNING` might be considered outside of the scope of the TODO language, and maybe it should live in a different language.

### Applicable Issues

There shouldn't be any issues since I just added 1 more keyword to the existing language and snippet.
