### PR TITLE
Add 'WIP' (work-in-progress) identifier to grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Windows Build Status](https://ci.appveyor.com/api/projects/status/gcgb9m7h146lv6qp/branch/master?svg=true)](https://ci.appveyor.com/project/Atom/language-todo/branch/master)
 [![Dependency Status](https://david-dm.org/atom/language-todo.svg)](https://david-dm.org/atom/language-todo)
 
-Adds syntax highlighting to `TODO`, `FIXME`, `CHANGED`, `XXX`, `IDEA`, `HACK`, `NOTE`, `REVIEW`, `NB`, `BUG`, `QUESTION`, `COMBAK`, `TEMP`, `DEBUG`, `OPTIMIZE`, and `WARNING` in comments
+Adds syntax highlighting to `TODO`, `WIP`, `FIXME`, `CHANGED`, `XXX`, `IDEA`, `HACK`, `NOTE`, `REVIEW`, `NB`, `BUG`, `QUESTION`, `COMBAK`, `TEMP`, `DEBUG`, `OPTIMIZE`, and `WARNING` in comments
 and text in Atom.
 
 Originally [converted](http://flight-manual.atom.io/hacking-atom/sections/converting-from-textmate) from the [TODO TextMate bundle](https://github.com/textmate/todo.tmbundle).

--- a/grammars/todo.cson
+++ b/grammars/todo.cson
@@ -2,7 +2,7 @@
 'injectionSelector': 'comment, text.plain'
 'patterns': [
   {
-    'match': '(?<!\\w)@?(TODO|FIXME|CHANGED|XXX|IDEA|HACK|NOTE|REVIEW|NB|BUG|QUESTION|COMBAK|TEMP|DEBUG|OPTIMIZE|WARNING)\\b'
+    'match': '(?<!\\w)@?(TODO|WIP|FIXME|CHANGED|XXX|IDEA|HACK|NOTE|REVIEW|NB|BUG|QUESTION|COMBAK|TEMP|DEBUG|OPTIMIZE|WARNING)\\b'
     'name': 'storage.type.class.${1:/downcase}'
   }
   {


### PR DESCRIPTION
Increasingly so there are changes in the codebase that may not be brittle, but would still not qualify as a _"Feature"_. This PR asks for the addition of "WIP" designator to the language-todo as a first-class citizen. This would be useful in the environment where a number of daily commits is necessary to facilitate team collaboration and peer review, as well as certain product- and project-management KPIs.

Edit: As you can see, I've added it as the second in the list of identifiers highlighted by this language as it fits nicely in the logical link of `TODO -> WIP`.