### PR TITLE
Add TESTME keyword to language-todo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Windows Build Status](https://ci.appveyor.com/api/projects/status/gcgb9m7h146lv6qp/branch/master?svg=true)](https://ci.appveyor.com/project/Atom/language-todo/branch/master)
 [![Dependency Status](https://david-dm.org/atom/language-todo.svg)](https://david-dm.org/atom/language-todo)
 
-Adds syntax highlighting to `TODO`, `FIXME`, `CHANGED`, `XXX`, `IDEA`, `HACK`, `NOTE`, `REVIEW`, `NB`, `BUG`, `QUESTION`, `COMBAK`, `TEMP`, `DEBUG`, `OPTIMIZE`, and `WARNING` in comments
+Adds syntax highlighting to `TODO`, `FIXME`, `CHANGED`, `XXX`, `IDEA`, `HACK`, `NOTE`, `REVIEW`, `NB`, `BUG`, `QUESTION`, `COMBAK`, `TEMP`, `DEBUG`, `OPTIMIZE`, `WARNING` and `TESTME` in comments
 and text in Atom.
 
 Originally [converted](http://flight-manual.atom.io/hacking-atom/sections/converting-from-textmate) from the [TODO TextMate bundle](https://github.com/textmate/todo.tmbundle).

--- a/grammars/todo.cson
+++ b/grammars/todo.cson
@@ -2,7 +2,7 @@
 'injectionSelector': 'comment, text.plain'
 'patterns': [
   {
-    'match': '(?<!\\w)@?(TODO|FIXME|CHANGED|XXX|IDEA|HACK|NOTE|REVIEW|NB|BUG|QUESTION|COMBAK|TEMP|DEBUG|OPTIMIZE|WARNING)\\b'
+    'match': '(?<!\\w)@?(TODO|FIXME|CHANGED|XXX|IDEA|HACK|NOTE|REVIEW|NB|BUG|QUESTION|COMBAK|TEMP|DEBUG|OPTIMIZE|WARNING|TESTME)\\b'
     'name': 'storage.type.class.${1:/downcase}'
   }
   {

--- a/snippets/todo.cson
+++ b/snippets/todo.cson
@@ -41,6 +41,9 @@
   'warning':
     'prefix': 'warning'
     'body': '# WARNING: $0'
+  'testme':
+    'prefix': 'testme'
+    'body': '# TESTME: $0'
 
 '.text.haml':
   'todo':
@@ -85,6 +88,9 @@
   'warning':
     'prefix': 'warning'
     'body': '-# WARNING: $0'
+  'testme':
+    'prefix': 'testme'
+    'body': '-# TESTME: $0'
 
 '.text.html.ruby, .text.erb':
   'todo':
@@ -129,6 +135,9 @@
   'warning':
     'prefix': 'warning'
     'body': '<%# WARNING: $0 %>'
+  'testme':
+    'prefix': 'testme'
+    'body': '<%# TESTME: $0 %>'
 
 '.text.html.ruby .meta.tag, .text.erb .meta.tag':
   'todo':
@@ -159,6 +168,8 @@
     'prefix': 'optimize'
   'warning':
     'prefix': 'warning'
+  'testme':
+    'prefix': 'testme'
 
 '.html.basic':
   'todo':
@@ -203,6 +214,9 @@
   'warning':
     'prefix': 'warning'
     'body': '<!-- WARNING: $0 -->'
+  'testme':
+    'prefix': 'testme'
+    'body': '<!-- TESTME: $0 -->'
 
 '.html.basic .meta.tag':
   'todo':
@@ -233,6 +247,8 @@
     'prefix': 'optimize'
   'warning':
     'prefix': 'warning'
+  'testme':
+    'prefix': 'testme'
 
 '.source.scss, .source.sass, .source.css.scss, .source.css.sass, .source.css.less, .source.js, .source.go, .source.scala, .source.ts, .source.php, .source.java':
   'todo':
@@ -277,6 +293,9 @@
   'warning':
     'prefix': 'warning'
     'body': '// WARNING: $0'
+  'testme':
+    'prefix': 'testme'
+    'body': '// TESTME: $0'
 
 '.source.css':
   'todo':
@@ -321,6 +340,9 @@
   'warning':
     'prefix': 'warning'
     'body': '/* WARNING: $0 */'
+  'testme':
+    'prefix': 'testme'
+    'body': '/* TESTME: $0 */'
 
 '.source.css .meta.property-value':
   'todo':
@@ -351,6 +373,8 @@
     'prefix': 'optimize'
   'warning':
     'prefix': 'warning'
+  'testme':
+    'prefix': 'testme'
 
 '.text.html.php':
   'todo':
@@ -395,3 +419,6 @@
   'warning':
     'prefix': 'warning'
     'body': '<?php // WARNING: $1 ?>$0'
+  'testme':
+    'prefix': 'testme'
+    'body': '<?php // TESTME: $1 ?>$0'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Add `TESTME` keyword to grammar as another todo keyword. Added to the README and
snippets as well.

### Alternate Designs

I feel like the `TESTME` keyword was something missing from the grammar. It works as a more specific call to future action specifically for marking a section as needing testing to be written.

### Benefits

The `TESTME` keyword is a new keyword targeted towards improving test coverage, which seems that it should be tracked separate from a standard `TODO` or any of the other keywords currently present in `language-todo`.

### Possible Drawbacks

It could be not universally useful and may be particularly dependent on the language being written.

### Applicable Issues

None.
