### PR TITLE
Added .source.shell

### DIFF
--- a/snippets/todo.cson
+++ b/snippets/todo.cson
@@ -1,4 +1,4 @@
-'.source.ruby, .source.puppet, .source.coffee, .source.python':
+'.source.ruby, .source.puppet, .source.coffee, .source.python, .source.shell':
   'todo':
     'prefix': 'todo'
     'body': '# TODO: $0'


### PR DESCRIPTION
### Description of the Change

Adding support for .source.shell

### Alternate Designs

None

### Benefits

Enable TODO comments snippets to be used in bash scripts

### Possible Drawbacks

.source.shell may apply to other shell script languages where the comment syntax is not #

### Applicable Issues

#97 
